### PR TITLE
api design: tweaks to naming and get-lists-of-ids

### DIFF
--- a/admin/controllers/api/light.js
+++ b/admin/controllers/api/light.js
@@ -26,6 +26,10 @@ exports.deleteJarLightImage = function(req, res) {
 
 // Firefly stuff
 
+exports.getFireflySwarms = function(req, res) {
+    return res.json({ status: 'error', message: 'Method not yet implemented' });
+}
+
 // set the blink interval (which probably ends up following a gaussian)
 exports.setFireflyBlinkInterval = function(req, res) {
     // req.body.swarmId = swarm type to modify 

--- a/admin/routes/api.js
+++ b/admin/routes/api.js
@@ -36,9 +36,11 @@ router.delete('/light/jar/images/:imageId', lightController.deleteJarLightImage)
 
 // Firefly Light Routes
 
-router.put('/light/fireflies/interval/:interval', lightController.setFireflyBlinkInterval);
+router.get('/light/fireflies/swarms', lightController.getFireflySwarms);
 
-router.put('/light/fireflies/color/:color', lightController.setFireflyLightColor);
+router.put('/light/fireflies/:swarmId/interval/:interval', lightController.setFireflyBlinkInterval);
+
+router.put('/light/fireflies/:swarmId/color/:color', lightController.setFireflyLightColor);
 
 // SOUND routes
 

--- a/design.txt
+++ b/design.txt
@@ -21,6 +21,10 @@ single large sculpture, we have three separate bugs. I'd suggest
 that we (mostly) define sequences that run on a single bug, with
 the exception of an all-poof (always a favorite) and a global chase.
 
+Since the admin console and the central controller are separate, the admin
+console depends on the controller for lists of IDs (bug, sound controller, and
+so forth) rather than coding / loading it in two places.
+
 Assuming that we have a mechanism to define the sequences, the API 
 to the UI would look something like:
 PUT /flames/sequences/<sequencename> bugid=<bugid>
@@ -29,6 +33,7 @@ PUT /flames/poofers/<pooferid> on=<tf> duration=<some_relatively_short_duration>
 POST /flames/sequences/<sequencename>
 GET /flames/sequences
 GET /flames/poofers 
+GET /flames/bugs (bugid is also used for jar LEDs)
 DELETE /flames/sequences/<sequencename> (although dont allow deletion of built in all-poof and chase)
 
 Jar LED Effects
@@ -36,32 +41,52 @@ I'm imagining the same sort of thing as above, except without the ability to
 add and delete patterns from the fuel depot. Although we might want to allow
 people to add images... Anyway - there's one Jar piece for each bug, so 
 the API looks some thing like:
-PUT /jarleds/patterns/<patternid> bugid=<bugid> image=<imageid>
-GET /jarleds/patterns
-GET /leds/images (if we can use images. Images end up being a good way to grab a 
+PUT /light/jar/patterns/<patternid> bugid=<bugid> image=<imageid>
+GET /light/jar/patterns
+GET /light/jar/images (if we can use images. Images end up being a good way to grab a
 color palette, even if we can't project the actual image on the the jar. See the
 Soma code for an example of this)
-POST /leds/images
-DELETE /leds/images/<imageid>
+POST /light/jar/images
+DELETE /light/jar/images/<imageid>
 
 Firefly Effects
 Here we can set the blink interval (which probably ends up following a gaussian)
 and a color. There are probably other interesting effects as well - think of more!
-PUT /fireflyleds/interval/<interval> swarmid=<swarmid>
-PUT /fireflyleds/color/<color (or color sequence)? swarmid=<swarmid>
+GET /light/firefly/swarms
+PUT /light/firefly/interval/<interval> swarmid=<swarmid>
+PUT /light/firefly/color/<color (or color sequence)? swarmid=<swarmid>
 
 Sound Effects
 Looking at what Ted was showing a couple of weeks back, we seem to have the
 ability to layer sound effects over one another, and to turn off a particular
 effect. I'd also like to have some controls over the ambient buzzing sound as well.
 There are a (currently unknown) number of separate sound controllers in the field. 
+
+NOTE: The sound API is likely to change significantly. Comments from cswales:
+
+https://github.com/FlamingLotusGirls/Serenity/pull/1#issuecomment-496274887
+
+> In terms of what the sound system can do - each controller has two different
+> output channels that can be controlled independently. In each channel we can mix
+> together a set of sound effects, and those effects can be layered on top of one
+> another. The button box that Ted showed me had a button for 'add more sound
+> effect X' and another for 'stop all sound effect X'. Thinking at a design level,
+> I'd like to have a certain background noise/drone/effects that the participants
+> *cant* change, and then ideally some set of buttons like Ted's that the
+> participants can use to add additional sounds on top of the ambient. That says
+> that our admin app definitely needs to be able to modify, save, and restore the
+> ambient, and probably needs to be able to have some control over the effect
+> overlays. Which of course also says that the APIs I tossed out there are
+> hopelessly inadequate. 
+
 PUT /sound/effects/<soundeffectid> controllerid=<soundcontrollerid> onoff=<tf> (add/subtract sound effect to general noise)
 GET /sound/effects/
-PUT /sound/volume/<volumelevel... 0-100> controllerid=<soundcontrollerid>
-POST /sound/volume_settings/<settinggid>  (save current settings for volume under a tag)
-DELETE /sound/volume_settings/<settingid>
-GET /sound/volume_settings/
-GET /sound/volume_settings/<settingid>
-PUT /sound/volume_settings/<settingid> (apply specified volume settings)
+GET /sound/controllers/
+PUT /sound/<soundControllerId>/volume/ volumelevel=<0-100>
+POST /sound/presets/<presetId>  (save current settings for volume under a tag)
+DELETE /sound/presets/<presetId> (don't allow deletion of built-in "silence" tag)
+GET /sound/presets/
+GET /sound/presets/<presetId>
+PUT /sound/presets/<presetId> (apply specified volume settings)
 
 


### PR DESCRIPTION
Add more "get a list of [x]" to the API, so the admin interface can
depend on the controller rather than hardcoding / knowing how to read
the sculpture configuration

Rename some REST paths in the design based on the admin controller
routes