### PR TITLE
Flames Service: always send responses with CORS headers

### DIFF
--- a/flames/flames_webserver.py
+++ b/flames/flames_webserver.py
@@ -52,16 +52,16 @@ def flame_status():
             elif playState == "play":
                 flames_controller.globalRelease()
             else:
-                return Response("Invalid 'playState' value", 400)
+                return makeJsonResponse("Invalid 'playState' value", 400)
         else:
-            return Response("Must have 'playState' value", 400)
+            return makeJsonResponse("Must have 'playState' value", 400)
 
-        return Response("", 200)
+        return makeJsonResponse("", 200)
 
     else:
         return makeJsonResponse(json.dumps(get_status()))
 
-def makeJsonResponse(jsonString, respStatus=200):
+def makeJsonResponse(jsonString="{}", respStatus=200):
     resp = Response(jsonString, status=respStatus, mimetype='application/json')
     resp.headers['Access-Control-Allow-Origin'] = '*'
     return resp
@@ -77,7 +77,7 @@ def specific_flame_status(poofer_id):
         abort(400)
     if request.method == 'POST':
         if not "enabled" in request.values:
-            return Response("'enabled' must be present", 400)
+            return makeJsonResponse("'enabled' must be present", 400)
 
         enabled = request.values["enabled"].lower()
         if enabled == 'true':
@@ -85,9 +85,10 @@ def specific_flame_status(poofer_id):
         elif enabled == 'false':
             flames_controller.disablePoofer(poofer_id)
         else:
-            return Response("Invalid 'enabled' value", 400)
+            return makeJsonResponse("Invalid 'enabled' value", 400)
 
-        return "" # XXX check for errors as a matter of course
+        # XXX check for errors as a matter of course
+        return makeJsonResponse()
     else:
         return makeJsonResponse(json.dumps(get_poofer_status(poofer_id)))
         
@@ -101,10 +102,10 @@ def flame_patterns():
         return makeJsonResponse(json.dumps(get_flame_patterns()))
     else:
         if not "patternData" in request.values:
-            return Response("'patternData' must be present", 400)
+            return makeJsonResponse("'patternData' must be present", 400)
         else:
             set_flame_pattern(request.values["patternData"])
-            return Response("", 200)
+            return makeJsonResponse("", 200)
 
 
 @app.route("/flame/patterns/<patternName>", methods=['GET', 'POST', 'DELETE'])
@@ -121,7 +122,7 @@ def flame_pattern(patternName):
     if request.method == 'POST':
         # pattern create - pattern data included, but pattern name not in system
         if  (not includesPattern) and (not patternName_valid(patternName)):
-            return Response("Must have valid 'patternName'", 400)
+            return makeJsonResponse("Must have valid 'patternName'", 400)
 
         if includesPattern:
             patternData = json.loads(request.values["pattern"])
@@ -161,16 +162,15 @@ def flame_pattern(patternName):
             elif (active == "false"):
                 flames_controller.stopFlameEffect(patternName)
 
-
-        return ""
+        return makeJsonResponse()
     elif request.method == "DELETE":
         pattern_manager.deletePattern(patternName)
         pattern_manager.savePatterns()
-        return ""
+        return makeJsonResponse()
 
     else:
         if (not patternName_valid(patternName)):
-            return Response("Must have valid 'patternName'", 400)
+            return makeJsonResponse("Must have valid 'patternName'", 400)
         else:
             return makeJsonResponse(json.dumps(get_pattern_status(patternName)))
 


### PR DESCRIPTION
I noticed that requests to some endpoints from the client were showing an error in-console and not giving me the response text, despite completing successfully. Turns out that not all endpoints were sending CORS headers.

To fix this, I just moved all responses to go through `makeJsonResponse`, and gave it a default text so we never have blank responses (which can confuse some things). They're not all really JSON so it's not strictly named correctly anymore, but seems reasonable enough!