### PR TITLE
Move firefly LED service from port 6000 to 7000

### DIFF
--- a/leds/fireflies/firefly_led_service.py
+++ b/leds/fireflies/firefly_led_service.py
@@ -15,7 +15,7 @@ import led_controller
     REST service for controlling firefly leds
 '''
 
-PORT = 6000
+PORT = 7000
 
 logger = logging.getLogger("firefly_leds")
 
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
     logging.basicConfig(format='%(asctime)-15s %(levelname)s %(module)s %(lineno)d: %(message)s', level=logging.DEBUG)
 
-    flaskThread = Thread(target=serve_forever, args=[6000])
+    flaskThread = Thread(target=serve_forever, args=[7000])
     flaskThread.start()
 
     print("About to make request!")


### PR DESCRIPTION
Chrome wouldn't make requests to the firefly LED service on port 6000 - it throws an `ERR_UNSAFE_PORT`. Turns out Chrome has a few blacklisted ports that it just will not make requests to - you can see the full list [here](https://superuser.com/questions/188058/which-ports-are-considered-unsafe-by-chrome).

7000 seemed like a fine choice, though we can also do 6001 if you don't want to skip the 6000s entirely!